### PR TITLE
Ignore ExamQuestions.txt and .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 ProfessorHomeDirectory
 *.pyc
 omsi_answer*
+ExamQuestions.txt
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 ProfessorHomeDirectory
 *.pyc
 omsi_answer*
-ExamQuestions.txt
+/ExamQuestions.txt
 .DS_Store


### PR DESCRIPTION
- `ExamQuestions.txt`: Downloaded file from the server
- `.DS_Store`: macOS temp file created by Finder

`.idea` folder, `*.txt~` and `.vimrc` should probably also be ignored. But it is NOT included in this pull request since I saw #1  is dealing with them right now.