### PR TITLE
Add email validation

### DIFF
--- a/OmsiGui.py
+++ b/OmsiGui.py
@@ -11,6 +11,7 @@ import sys, subprocess
 import filecmp
 import time
 import OmsiClient 
+import re
 
 import pdb
 
@@ -504,11 +505,13 @@ class OmsiGui(Frame):
             self.email = self.emailEntry.get()
             if not self.host or not self.port or not self.email:
                 raise ValueError
+            if not re.match('[a-z0-9]+@ucdavis\.edu', self.email):
+                tkMessageBox.showwarning("Bad input", "Invalid Email Address!")
+                return 0
             return 1
+
         except ValueError:
-            tkMessageBox.showwarning(
-                "Bad input", "Enter host, post and email!"
-            )
+            tkMessageBox.showwarning("Bad input", "Enter host, port, and email!")
             return 0
 
     # Parses the question file to separate questions.

--- a/OmsiGui.py
+++ b/OmsiGui.py
@@ -505,7 +505,7 @@ class OmsiGui(Frame):
             self.email = self.emailEntry.get()
             if not self.host or not self.port or not self.email:
                 raise ValueError
-            if not re.match('[a-z0-9]+@ucdavis\.edu', self.email):
+            if not re.match('^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$', self.email):
                 tkMessageBox.showwarning("Bad input", "Invalid Email Address!")
                 return 0
             return 1


### PR DESCRIPTION
Add email validation when connecting to the server.

Prints "Invalid Email Address" if the email is invalid based on the regex pattern `[a-z0-9]+@ucdavis\.edu`

I am not sure if UCD emails can contain number so I allowed numbers to be safe

**Edit**
Relax email vitrifaction for any email type"
