### PR TITLE
Graphic out

### DIFF
--- a/OmsiGui.py
+++ b/OmsiGui.py
@@ -253,6 +253,13 @@ class OmsiGui(Frame):
     def viewPDF(self):
        os.system(self.pdfCmd)
 
+    def viewGraph(self):
+        if self.pdfCmd != None:
+            try:
+                os.system(self.pdfCmd.split(' ')[0] + " Rplots.pdf")
+                pass
+            except:
+                tkMessageBox.showwarning("Error with open command!")
 
     def runProgram(self, qNum = None):       
         self.submitAnswer()
@@ -322,12 +329,6 @@ class OmsiGui(Frame):
                 outfile.close()
             os.remove("errfile") 
             os.remove("o_" + str(qNum))
-            if self.pdfCmd != None:
-                try:
-                    os.system(self.pdfCmd.split(' ')[0] + " Rplots.pdf")
-                    pass
-                except:
-                    tkMessageBox.showwarning("Error with open command!")
 
         else:
         # this question does not allow run
@@ -539,6 +540,7 @@ class OmsiGui(Frame):
         filemenu.add_command(label="Submit & Run", command=self.runProgram)
         filemenu.add_command(label="CopyQtoA", command=self.copyQtoA)
         filemenu.add_command(label="View PDF", command=self.viewPDF)
+        filemenu.add_command(label="View R graphs", command=self.viewGraph)
 
         filemenu.add_separator()
 

--- a/OmsiGui.py
+++ b/OmsiGui.py
@@ -322,12 +322,13 @@ class OmsiGui(Frame):
                 outfile.close()
             os.remove("errfile") 
             os.remove("o_" + str(qNum))
-            try:
-                os.system("evince Rplots.pdf") 
-                pass
-            except:
-                os.system(self.pdfCmd.split(' ')[] + " Rplots.pdf")
-                pass
+            if self.pdfCmd != None:
+                try:
+                    os.system(self.pdfCmd.split(' ')[0] + " Rplots.pdf")
+                    pass
+                except:
+                    tkMessageBox.showwarning("Error with open command!")
+
         else:
         # this question does not allow run
             msg = "\nNot authorised!\n"

--- a/OmsiGui.py
+++ b/OmsiGui.py
@@ -253,6 +253,7 @@ class OmsiGui(Frame):
     def viewPDF(self):
        os.system(self.pdfCmd)
 
+
     def runProgram(self, qNum = None):       
         self.submitAnswer()
         runCmd = ""
@@ -267,10 +268,8 @@ class OmsiGui(Frame):
         #check if this program can be "run"
             fType = self.QuestionsArr[qNum].getFiletype()  #file type
             #name of the file to be compiled
-            fName = "omsi_answer{0}{1}". \
-               format(qNum, self.QuestionsArr[qNum].getFiletype()) 
+            fName = "omsi_answer{0}{1}".format(qNum, fType) 
             compileProg = self.QuestionsArr[qNum].getCompileProgram()
-            
             if compileProg == 'y':
             #check if executable exists (if required)
                 execName = "omsi_answer" + str(qNum)  #name of the executable    
@@ -322,7 +321,13 @@ class OmsiGui(Frame):
                    join(outfile.readlines()) + "\n"
                 outfile.close()
             os.remove("errfile") 
-            os.remove("o_" + str(qNum)) 
+            os.remove("o_" + str(qNum))
+            try:
+                os.system("evince Rplots.pdf") 
+                pass
+            except:
+                os.system(self.pdfCmd.split(' ')[] + " Rplots.pdf")
+                pass
         else:
         # this question does not allow run
             msg = "\nNot authorised!\n"
@@ -330,6 +335,8 @@ class OmsiGui(Frame):
             return False
 
         # display msg in pop-up box
+        # Display the image that was created here as well
+        #   Or create a new popup
         fileWin = Toplevel(self.parent)
         text = Text(fileWin)
         text.insert(END,msg)
@@ -598,7 +605,6 @@ class OmsiGui(Frame):
         # self.txt.grid(row=1,sticky="nswe",pa dx=5,pady=5)
         pWindow.pack(fill=BOTH, expand=1, pady=5)
         # self.loadQuestionsFromFile()
-
 
 def main():
     top = Tk()


### PR DESCRIPTION
R has been saving the plots of whatever it runs, but can't display, within the local directory.

What I do is just call the user-supplied 'open' function on the pdf that gets created when the user wants to. The command is in a dropdown window, so the user can select when to see their output.

I have tested it on my Ubuntu laptop, as well as my Windows desktop. They work fine. I added some error validation if the 'open' command does not work, OR if the PDF containing the graph does not exist.

I would like to do two more things with this.

1. Save old graphs, and allow lookback for them
2. Have TKinter actually open them within its own GUI. I think this would create some more speed, just so the OS does not have to start another program. I don't think Tkinter has any built-in PDF support, however. So stripping out the image from the PDF and converting it to something the GUI can load would be necessary, if we're not to add any additional dependencies.
